### PR TITLE
Corrected The Spelling of Facebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Canvas-Streaming-Example
-Facebok Streaming ,Canvas ,Facebook API
+Facebook Streaming ,Canvas ,Facebook API


### PR DESCRIPTION
Before:-
# Canvas-Streaming-Example
Facebok Streaming ,Canvas ,Facebook API

After:-
Facebook Streaming ,Canvas ,Facebook API